### PR TITLE
Fixing 'compose' on the first run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ custom-root.tar
 boot.tar
 custom.img
 raspbian.img
+partition_table.txt

--- a/support/1-extract.sh
+++ b/support/1-extract.sh
@@ -26,6 +26,7 @@ fi
 do_umount
 set -e
 
+echo "Creating ${PT_FILENAME}"
 sfdisk -d "${1}" > "${PT_FILENAME}"
 
 losetup -a | grep "${1}" | awk -F: '{ print $1 }' | \

--- a/support/3-compose.sh
+++ b/support/3-compose.sh
@@ -19,12 +19,17 @@
 export CUSTOM_IMG_NAME=custom.img
 RSYNC_FLAGS="-vh --progress --modify-window=1 --recursive --ignore-errors"
 
+. $(dirname "$0")/functions.sh
+
 if [ -z "$1" ] ; then
     echo "No hostname given"
     exit 1
 fi
 
-. $(dirname "$0")/functions.sh
+if [ ! -f "${PT_FILENAME}" ] ; then
+    echo "No partition table found (${PT_FILENAME}). Run 'extract' first!"
+    exit 1
+fi
 
 do_umount
 set -e


### PR DESCRIPTION
> Hey there! Not sure if you plan on maintaining this at all, but I've found it useful so I might submit some small improvements in the future. Hope that's okay! (:

The `compose` step was failing when run for the first time (`losetup: custom.img: failed to set up loop device: No such file or directory`). Had to change the order of operations to initialize `custom.img` with `dd` first.